### PR TITLE
Update oathkeeper proxy endpoint

### DIFF
--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -1,4 +1,4 @@
-export const officialAPIEndpoint = 'https://api.openai.com/v1/chat/completions';
+export const officialAPIEndpoint = 'https://dev-proxy.zurutech.online/public/openai-public';
 const customAPIEndpoint =
   import.meta.env.VITE_CUSTOM_API_ENDPOINT || 'https://chatgpt-api.shn.hk/v1/';
 export const defaultAPIEndpoint =


### PR DESCRIPTION
I have updated the ZURU proxy endpoint to access the ChatGPT OpenAI URL.